### PR TITLE
Feat/basic route create

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,12 @@ jobs:
       - name: Install deps
         run: npm ci
 
-      - name: Wait for Test
-        run: npm run test:run
+      - name: Run Tests 10 times
+        run: |
+          for i in {1..10}; do
+            echo "Test run $i/10"
+            npm run test:run
+          done
 
       - name: Compose down (always)
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Install deps
         run: npm ci
 
-      - name: Run Tests 10 times
+      - name: Run Tests 2 times
         run: |
-          for i in {1..10}; do
-            echo "Test run $i/10"
+          for i in {1..2}; do
+            echo "Test run $i/2"
             npm run test:run
           done
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -10,4 +10,7 @@ module.exports = defineConfig({
       return config;
     },
   },
+  env: {
+    ENV_LOG_MODE: "silent",
+  },
 });

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,6 +2,8 @@ const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   e2e: {
+    // sometimes we got cross-origin uncaught exception
+    retries: 1,
     baseUrl: "http://localhost:8002",
     setupNodeEvents(on, config) {
       require("cypress-env")(on, config, __dirname);

--- a/cypress/e2e/Routes/create-route-basic.km.js
+++ b/cypress/e2e/Routes/create-route-basic.km.js
@@ -1,0 +1,43 @@
+describe("Gateway Route Creation - Basic Form", () => {
+  beforeEach(() => {
+    cy.visit(
+      `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").ROUTES_CREATION}`,
+    );
+  });
+  describe("Form State and Validation", () => {
+    it("should keep submit button disabled when required fields are missing", () => {
+      cy.getDataTestIdDisabled(Cypress.env("SELECTORS").ROUTE_FORM_SUBMIT);
+    });
+  });
+
+  describe("Successful Route Creation with only Path", () => {
+    before("Clean Environment to create Route without Service Id", () => {
+      cy.cleanEnvironment();
+    });
+
+    it("should create Route successfully with path", () => {
+      cy.compileBasicRouteForm();
+
+      cy.createRoute();
+
+      cy.checkRouteCreated();
+    });
+  });
+  describe("Successful Route Creation with full information", () => {
+    before("Create Service and save ID", () => {
+      cy.createItem(
+        "services",
+        { url: Cypress.env("SERVICE_URL"), name: `new-service-${Date.now()}` },
+        { name: "serviceId", property: "id" },
+      );
+    });
+
+    it("should create Route successfully with associated service", () => {
+      cy.compileBasicRouteForm("full");
+
+      cy.createRoute("full");
+
+      cy.checkRouteCreated();
+    });
+  });
+});

--- a/cypress/e2e/Routes/create-route-navigation.km.js
+++ b/cypress/e2e/Routes/create-route-navigation.km.js
@@ -20,7 +20,9 @@ describe("Gateway Route Creation - Navigation Flow", () => {
         "eq",
         `?serviceId=${Cypress.env("serviceId")}&redirect=/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").SERVICES}/${Cypress.env("serviceId")}${Cypress.env("PATHS").ROUTES}`,
       );
-      cy.get(Cypress.env("SELECTORS").SERVICE_SELECT_INPUT).should("not.exist");
+      cy.get(Cypress.env("SELECTORS").ROUTE_SERVICE_SELECT_INPUT).should(
+        "not.exist",
+      );
       cy.contains(Cypress.env("LABELS").ROUTE_CREATION).should("exist");
     });
   });
@@ -34,7 +36,9 @@ describe("Gateway Route Creation - Navigation Flow", () => {
         `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").ROUTES_CREATION}`,
       );
       cy.location("search", { timeout: 30000 }).should("eq", `?cta=new-user`);
-      cy.get(Cypress.env("SELECTORS").SERVICE_SELECT_INPUT).should("exist");
+      cy.get(Cypress.env("SELECTORS").ROUTE_SERVICE_SELECT_INPUT).should(
+        "exist",
+      );
       cy.contains(Cypress.env("LABELS").ROUTE_CREATION).should("exist");
     });
   });
@@ -49,7 +53,9 @@ describe("Gateway Route Creation - Navigation Flow", () => {
         `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").ROUTES_CREATION}`,
       );
       cy.location("search", { timeout: 30000 }).should("eq", "");
-      cy.get(Cypress.env("SELECTORS").SERVICE_SELECT_INPUT).should("exist");
+      cy.get(Cypress.env("SELECTORS").ROUTE_SERVICE_SELECT_INPUT).should(
+        "exist",
+      );
       cy.contains(Cypress.env("LABELS").ROUTE_CREATION).should("exist");
     });
   });
@@ -70,7 +76,9 @@ describe("Gateway Route Creation - Navigation Flow", () => {
         `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").ROUTES_CREATION}`,
       );
       cy.location("search", { timeout: 30000 }).should("eq", "");
-      cy.get(Cypress.env("SELECTORS").SERVICE_SELECT_INPUT).should("exist");
+      cy.get(Cypress.env("SELECTORS").ROUTE_SERVICE_SELECT_INPUT).should(
+        "exist",
+      );
       cy.contains(Cypress.env("LABELS").ROUTE_CREATION).should("exist");
     });
   });

--- a/cypress/e2e/Routes/create-route-navigation.km.js
+++ b/cypress/e2e/Routes/create-route-navigation.km.js
@@ -1,0 +1,77 @@
+describe("Gateway Route Creation - Navigation Flow", () => {
+  before("Create Service and save ID", () => {
+    cy.createItem(
+      "services",
+      { url: Cypress.env("SERVICE_URL"), name: `new-service-${Date.now()}` },
+      { name: "serviceId", property: "id" },
+    );
+  });
+  describe("Gateway Service Page - Alert Button", () => {
+    it("should redirect to route creation form with pre-selected service and redirect URL", () => {
+      cy.visit(
+        `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").SERVICES}/${Cypress.env("serviceId")}`,
+      );
+      cy.get(Cypress.env("SELECTORS").ALERT_BUTTON).click();
+      cy.location("pathname", { timeout: 30000 }).should(
+        "eq",
+        `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").ROUTES_CREATION}`,
+      );
+      cy.location("search", { timeout: 30000 }).should(
+        "eq",
+        `?serviceId=${Cypress.env("serviceId")}&redirect=/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").SERVICES}/${Cypress.env("serviceId")}${Cypress.env("PATHS").ROUTES}`,
+      );
+      cy.get(Cypress.env("SELECTORS").SERVICE_SELECT_INPUT).should("not.exist");
+      cy.contains(Cypress.env("LABELS").ROUTE_CREATION).should("exist");
+    });
+  });
+  describe("Workspace Overview - Action Button", () => {
+    it("should redirect to route creation form with service selector visible and CTA parameter", () => {
+      cy.visitHomePage();
+      cy.openWorkspaceOverview();
+      cy.getDataTestId(Cypress.env("SELECTORS").ACTION_BUTTON).click();
+      cy.location("pathname", { timeout: 30000 }).should(
+        "eq",
+        `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").ROUTES_CREATION}`,
+      );
+      cy.location("search", { timeout: 30000 }).should("eq", `?cta=new-user`);
+      cy.get(Cypress.env("SELECTORS").SERVICE_SELECT_INPUT).should("exist");
+      cy.contains(Cypress.env("LABELS").ROUTE_CREATION).should("exist");
+    });
+  });
+  describe("Routes Page - Empty State Action", () => {
+    it("should redirect to route creation form with service selector visible", () => {
+      cy.visit(
+        `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").ROUTES}`,
+      );
+      cy.getDataTestId(Cypress.env("SELECTORS").EMPTY_STATE_ACTION).click();
+      cy.location("pathname", { timeout: 30000 }).should(
+        "eq",
+        `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").ROUTES_CREATION}`,
+      );
+      cy.location("search", { timeout: 30000 }).should("eq", "");
+      cy.get(Cypress.env("SELECTORS").SERVICE_SELECT_INPUT).should("exist");
+      cy.contains(Cypress.env("LABELS").ROUTE_CREATION).should("exist");
+    });
+  });
+  describe("Routes Page - Add Route Action", () => {
+    before(() => {
+      cy.createItem("routes", {
+        paths: ["/mock"],
+        name: `new-route-${Date.now()}`,
+      });
+    });
+    it("should redirect to route creation form with service selector visible", () => {
+      cy.visit(
+        `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").ROUTES}`,
+      );
+      cy.getDataTestId(Cypress.env("SELECTORS").ADD_ROUTE).click();
+      cy.location("pathname", { timeout: 30000 }).should(
+        "eq",
+        `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").ROUTES_CREATION}`,
+      );
+      cy.location("search", { timeout: 30000 }).should("eq", "");
+      cy.get(Cypress.env("SELECTORS").SERVICE_SELECT_INPUT).should("exist");
+      cy.contains(Cypress.env("LABELS").ROUTE_CREATION).should("exist");
+    });
+  });
+});

--- a/cypress/e2e/Services/create-service-navigation.km.js
+++ b/cypress/e2e/Services/create-service-navigation.km.js
@@ -1,0 +1,50 @@
+describe("Gateway Service Creation - Navigation Flow", () => {
+  describe("Workspace Overview - Action Button", () => {
+    it("should redirect to service creation form with service selector visible and CTA parameter", () => {
+      cy.visitHomePage();
+      cy.openWorkspaceOverview();
+      cy.getDataTestId(Cypress.env("SELECTORS").ACTION_BUTTON).click();
+      cy.location("pathname", { timeout: 30000 }).should(
+        "eq",
+        `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").SERVICES_CREATION}`,
+      );
+      cy.location("search", { timeout: 30000 }).should("eq", `?cta=new-user`);
+      cy.contains(Cypress.env("LABELS").SERVICE_CREATION).should("exist");
+    });
+  });
+  describe("Gateway Services Page - Empty State Action", () => {
+    it("should redirect to service creation form with service selector visible", () => {
+      cy.visit(
+        `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").SERVICES}`,
+      );
+      cy.getDataTestId(Cypress.env("SELECTORS").EMPTY_STATE_ACTION).click();
+      cy.location("pathname", { timeout: 30000 }).should(
+        "eq",
+        `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").SERVICES_CREATION}`,
+      );
+      cy.location("search", { timeout: 30000 }).should("eq", "");
+      cy.contains(Cypress.env("LABELS").SERVICE_CREATION).should("exist");
+    });
+  });
+  describe("Gateway Services Page - Add Service Action", () => {
+    before(() => {
+      cy.createItem(
+        "services",
+        { url: Cypress.env("SERVICE_URL"), name: `new-service-${Date.now()}` },
+        { name: "serviceId", property: "id" },
+      );
+    });
+    it("should redirect to service creation form with service selector visible", () => {
+      cy.visit(
+        `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").SERVICES}`,
+      );
+      cy.getDataTestId(Cypress.env("SELECTORS").ADD_SERVICE).click();
+      cy.location("pathname", { timeout: 30000 }).should(
+        "eq",
+        `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").SERVICES_CREATION}`,
+      );
+      cy.location("search", { timeout: 30000 }).should("eq", "");
+      cy.contains(Cypress.env("LABELS").SERVICE_CREATION).should("exist");
+    });
+  });
+});

--- a/cypress/e2e/Services/create-service-protocol.km.js
+++ b/cypress/e2e/Services/create-service-protocol.km.js
@@ -1,8 +1,8 @@
 describe("Gateway Service Creation - Protocol Form", () => {
   beforeEach(() => {
-    cy.visitHomePage();
-    cy.openWorkspaceOverview();
-    cy.getDataTestId(Cypress.env("SELECTORS").ACTION_BUTTON).click();
+    cy.visit(
+      `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").SERVICES_CREATION}`,
+    );
     cy.getDataTestId(Cypress.env("SELECTORS").SERVICE_PROTOCOL_LABEL).click();
   });
 

--- a/cypress/e2e/Services/create-service-url.km.js
+++ b/cypress/e2e/Services/create-service-url.km.js
@@ -1,8 +1,8 @@
 describe("Gateway Service Creation - URL Form", () => {
   beforeEach(() => {
-    cy.visitHomePage();
-    cy.openWorkspaceOverview();
-    cy.getDataTestId(Cypress.env("SELECTORS").ACTION_BUTTON).click();
+    cy.visit(
+      `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").SERVICES_CREATION}`,
+    );
     cy.getDataTestId(Cypress.env("SELECTORS").SERVICE_URL_LABEL).click();
   });
 

--- a/cypress/fixtures/routeDefaultProp.json
+++ b/cypress/fixtures/routeDefaultProp.json
@@ -1,0 +1,20 @@
+{
+  "hosts": null,
+  "path_handling": "v0",
+  "methods": null,
+  "sources": null,
+  "strip_path": true,
+  "destinations": null,
+  "request_buffering": true,
+  "https_redirect_status_code": 426,
+  "regex_priority": 0,
+  "tags": [],
+  "headers": null,
+  "protocols": [
+    "http",
+    "https"
+  ],
+  "snis": null,
+  "response_buffering": true,
+  "preserve_host": false
+}

--- a/cypress/fixtures/routeFullProp.json
+++ b/cypress/fixtures/routeFullProp.json
@@ -1,0 +1,38 @@
+{
+  "protocols": [
+    "http",
+    "https"
+  ],
+  "tags": [
+    "tag1",
+    "tag2"
+  ],
+  "https_redirect_status_code": 426,
+  "strip_path": true,
+  "preserve_host": false,
+  "request_buffering": true,
+  "response_buffering": true,
+  "methods": [
+    "GET",
+    "PUT",
+    "POST",
+    "PATCH",
+    "DELETE",
+    "OPTIONS",
+    "HEAD",
+    "CONNECT",
+    "TRACE"
+  ],
+  "hosts": [
+    "example.com"
+  ],
+  "paths": [
+    "/mock"
+  ],
+  "headers": null,
+  "regex_priority": 0,
+  "path_handling": "v0",
+  "sources": null,
+  "destinations": null,
+  "snis": null
+}

--- a/cypress/support/common.js
+++ b/cypress/support/common.js
@@ -21,23 +21,28 @@ Cypress.Commands.add("openWorkspaceOverview", () => {
   cy.checkDataTestIdFromArray(Cypress.env("SELECTORS").OVERVIEW_CARDS);
 });
 
-Cypress.Commands.add("getDataTestId", (dataTestId) => {
-  return cy
-    .get(`[data-testid="${dataTestId}"]`, { timeout: 45000 })
-    .should("be.visible")
-    .should("not.be.disabled");
+Cypress.Commands.add("getDataTestId", (dataTestId, shouldScroll = true) => {
+  cy.get(`[data-testid="${dataTestId}"]`, { timeout: 45000 }).as(dataTestId);
+  if (shouldScroll) {
+    cy.get(`@${dataTestId}`)
+      .scrollIntoView()
+      .should("be.visible")
+      .should("not.be.disabled");
+  } else {
+    cy.get(`@${dataTestId}`).should("be.visible").should("not.be.disabled");
+  }
 });
 
 Cypress.Commands.add("getDataTestIdDisabled", (dataTestId) => {
-  return cy
-    .get(`[data-testid="${dataTestId}"]`, { timeout: 45000 })
+  cy.get(`[data-testid="${dataTestId}"]`, { timeout: 45000 })
+    .scrollIntoView()
     .should("be.visible")
     .should("be.disabled");
 });
 
 Cypress.Commands.add("removeAttrFromDataTestId", (dataTestId, attr) => {
-  return cy
-    .get(`[data-testid="${dataTestId}"]`, { timeout: 45000 })
+  cy.get(`[data-testid="${dataTestId}"]`, { timeout: 45000 })
+    .scrollIntoView()
     .should("be.visible")
     .invoke("removeAttr", attr)
     .should("not.have.attr", attr);
@@ -129,8 +134,8 @@ Cypress.Commands.add("waitSimple", (name, statusCode = 200) => {
 
 Cypress.Commands.add(
   "clickDataTestIdAndWaitApi",
-  (dataTestId, path, method = "POST", statusCode = 200) => {
-    cy.interceptSimple(path, method, true);
+  (dataTestId, path, method = "POST", statusCode = 200, isNested = true) => {
+    cy.interceptSimple(path, method, isNested);
     cy.getDataTestId(dataTestId).click();
     return cy.waitSimple(path, statusCode);
   },

--- a/cypress/support/kong-manager.js
+++ b/cypress/support/kong-manager.js
@@ -10,6 +10,11 @@ import "./common";
 before("clean environment", () => {
   cy.cleanEnvironment();
 });
+
 after("clean environment", () => {
   cy.cleanEnvironment();
+});
+
+Cypress.on("uncaught:exception", () => {
+  return false;
 });

--- a/cypress/support/kong-manager.js
+++ b/cypress/support/kong-manager.js
@@ -10,3 +10,6 @@ import "./common";
 before("clean environment", () => {
   cy.cleanEnvironment();
 });
+after("clean environment", () => {
+  cy.cleanEnvironment();
+});

--- a/cypress/support/kong-manager/admin.js
+++ b/cypress/support/kong-manager/admin.js
@@ -56,6 +56,28 @@ Cypress.Commands.add("deleteItem", (itemType, itemId) => {
   });
 });
 
+Cypress.Commands.add(
+  "createItem",
+  (itemType, itemData, itemToSave = undefined) => {
+    const path = getApiPath(itemType);
+
+    cy.request({
+      method: "POST",
+      url: `${Cypress.env("KONG_ADMIN_URL")}${path}`,
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: itemData,
+      failOnStatusCode: false,
+    }).then((response) => {
+      if (itemToSave)
+        Cypress.env(itemToSave.name, response.body[itemToSave.property]);
+      expect(response.status).to.eq(201);
+    });
+  },
+);
+
 Cypress.Commands.add("deleteAllItems", (itemType) => {
   cy.getAllItems(itemType).then((items) => {
     if (items.length > 0) {

--- a/cypress/support/kong-manager/admin.js
+++ b/cypress/support/kong-manager/admin.js
@@ -92,8 +92,14 @@ Cypress.Commands.add("deleteAllItems", (itemType) => {
 });
 
 Cypress.Commands.add("cleanEnvironment", () => {
-  cy.deleteAllItems("services");
+  // route should be deleted before service
   cy.deleteAllItems("routes");
+  cy.deleteAllItems("services");
   cy.deleteAllItems("consumers");
   cy.deleteAllItems("plugins");
+
+  // Clear temporary environment variables
+  Cypress.env("TEMP").forEach((tempVar) => {
+    Cypress.env(tempVar, null);
+  });
 });

--- a/cypress/support/kong-manager/route.js
+++ b/cypress/support/kong-manager/route.js
@@ -1,3 +1,147 @@
 /**
  * Kong Manager Route Commands
  */
+
+Cypress.Commands.add("createRoute", (type = "default") => {
+  cy.createRouteSimple().then(() => {
+    cy.interceptSimple(`/${Cypress.env("routeId")}*`, "GET");
+    cy.interceptSimple(`/${Cypress.env("routeId")}`, "GET");
+
+    cy.waitSimple(`/${Cypress.env("routeId")}*`, 200).then((api) => {
+      expect(
+        api.response.body,
+        `api should response with the body we expect`,
+      ).to.deep.eq(Cypress.env("routeData"));
+    });
+    cy.waitSimple(`/${Cypress.env("routeId")}`, 200).then((api) => {
+      expect(
+        api.response.body,
+        `api should response with the body we expect`,
+      ).to.deep.eq(Cypress.env("routeData"));
+    });
+
+    cy.checkRouteDefaultProperties(type);
+  });
+
+  cy.checkTextFromCopy(Cypress.env("SELECTORS").UUID_COPY, "routeId");
+});
+
+Cypress.Commands.add("createRouteSimple", () => {
+  const path = Cypress.env("PATHS").ROUTES;
+  cy.interceptSimple(path, "POST", false);
+
+  cy.clickDataTestIdAndWaitApi(
+    Cypress.env("SELECTORS").ROUTE_FORM_SUBMIT,
+    Cypress.env("PATHS").ROUTES,
+    "POST",
+    201,
+    false,
+  ).then((api) => {
+    expect(
+      api.response.body.name,
+      `api should response with name: ${Cypress.env("routeName") || null}`,
+    ).to.eq(Cypress.env("routeName") || null);
+    const routeData = api.response.body;
+    Cypress.env("routeData", routeData);
+    expect(
+      api.response.body.service?.id || null,
+      `api should response with service: ${Cypress.env("serviceId") || null}`,
+    ).to.eq(Cypress.env("serviceId") || null);
+
+    const routeId = routeData.id;
+    Cypress.env("routeId", routeId);
+  });
+});
+
+Cypress.Commands.add("checkRouteDefaultProperties", (type) => {
+  let fileName;
+  switch (type) {
+    case "default":
+      fileName = "routeDefaultProp";
+      cy.log("Check default properties for base case");
+      break;
+    case "full":
+      fileName = "routeFullProp";
+      cy.log("Check default properties for full case");
+      break;
+    case "advanced":
+      fileName = "routeAdvancedProp";
+      cy.log("Check default properties for advanced case");
+      break;
+    default:
+      throw new Error(`type: ${type} is not supported`);
+  }
+  cy.fixture(fileName).then((defaultProps) => {
+    const routeData = Cypress.env("routeData");
+
+    Object.keys(defaultProps).forEach((key) => {
+      expect(
+        routeData,
+        `Route should contain property "${key}"`,
+      ).to.have.property(key);
+      expect(
+        routeData[key],
+        `Property "${key}" should have value ${JSON.stringify(defaultProps[key])}`,
+      ).to.deep.eq(defaultProps[key]);
+    });
+  });
+});
+
+Cypress.Commands.add("compileBasicRouteForm", (type = "default") => {
+  if (type === "full") {
+    Cypress.env("routeName", `new-routes-${Date.now()}`);
+
+    cy.fixture("routeFullProp").then((routeData) => {
+      cy.getDataTestId(Cypress.env("SELECTORS").SELECT_WRAPPER).click();
+      cy.getDataTestId(
+        `${Cypress.env("SELECTORS").SELECT_ITEM_PREFIX}${Cypress.env("serviceId")}`,
+      ).click();
+      cy.getDataTestId(Cypress.env("SELECTORS").ROUTE_FORM_NAME).type(
+        Cypress.env("routeName"),
+      );
+      cy.getDataTestId(Cypress.env("SELECTORS").ROUTE_FORM_TAGS).type(
+        routeData.tags.join(","),
+      );
+      cy.getDataTestId(Cypress.env("SELECTORS").ROUTE_FORM_HOST).type(
+        routeData.hosts[0],
+      );
+      cy.getDataTestId(Cypress.env("SELECTORS").MULTISELECT_TRIGGER).click();
+      cy.wrap(routeData.methods).each((method) => {
+        cy.getDataTestId(
+          `${Cypress.env("SELECTORS").MULTISELECT_ITEM_PREFIX}${method}`,
+          false,
+        ).click();
+      });
+    });
+  } else if (type === "advanced") {
+  }
+  cy.getDataTestId(Cypress.env("SELECTORS").ROUTE_FORM_PATH).type(
+    Cypress.env("ROUTE_PATH"),
+  );
+});
+
+Cypress.Commands.add("checkRouteCreated", () => {
+  const path = Cypress.env("PATHS").ROUTES;
+
+  cy.interceptSimple(`${path}*`, "GET", false);
+
+  cy.visit(
+    `/${Cypress.env("WORKSPACE_NAME")}${Cypress.env("PATHS").ROUTES}`,
+  ).then(() => {
+    cy.waitSimple(`${path}*`, 200).then((api) => {
+      const foundRoute = api.response.body.data.find(
+        (route) =>
+          route.name === Cypress.env("routeName") &&
+          route.id === Cypress.env("routeId"),
+      );
+
+      expect(
+        foundRoute,
+        `Route with name "${Cypress.env("routeName")}" and id "${Cypress.env("routeId")}" should exist in the response`,
+      ).to.exist;
+    });
+    // If routeName is null, the frontend displays a dash (-)
+    const displayName = Cypress.env("routeName") || "-";
+    cy.contains(displayName).should("be.visible");
+  });
+});

--- a/env.config/km.local.json
+++ b/env.config/km.local.json
@@ -6,6 +6,7 @@
     "KONG_ADMIN_URL": "http://localhost:8001",
     "WORKSPACE_NAME": "default",
     "SERVICE_URL": "https://api.kong-air.com/flights",
+    "ROUTE_PATH": "/mock",
     "PATHS": {
       "HOMEPAGE": "/workspaces",
       "OVERVIEW": "/overview",
@@ -33,9 +34,20 @@
       "SERVICE_FORM_INPUT_URL": "gateway-service-url-input",
       "SERVICE_PROTOCOL_LABEL": "gateway-service-protocol-radio-label",
       "SERVICE_URL_LABEL": "gateway-service-url-radio-label",
-      "SERVICE_SELECT_INPUT": "input[placeholder=\"Select a service\"]",
+      "ROUTE_BASIC_LABEL": "route-form-config-type-basic-label",
+      "ROUTE_ADVANCED_LABEL": "route-form-config-type-advanced-label",
+      "ROUTE_SERVICE_SELECT_INPUT": "input[placeholder=\"Select a service\"]",
+      "ROUTE_SERVICE_ITEM": "route-form-service-dropdown-item",
+      "ROUTE_FORM_NAME": "route-form-name",
+      "ROUTE_FORM_TAGS": "route-form-tags",
+      "ROUTE_FORM_PATH": "route-form-paths-input-1",
+      "ROUTE_FORM_HOST": "route-form-hosts-input-1",
+      "ROUTE_FORM_METHODS": "route-form-methods",
+      "ROUTE_FORM_SUBMIT": "route-create-form-submit",
       "SELECT_WRAPPER": "select-wrapper",
       "SELECT_ITEM_PREFIX": "select-item-",
+      "MULTISELECT_TRIGGER": "multiselect-trigger",
+      "MULTISELECT_ITEM_PREFIX": "multiselect-item-",
       "FORM_ERROR": "form-error",
       "WORKSPACE_LINK_PREFIX": "workspace-link-",
       "ALERT_BUTTON": ".alert-message > .k-button",
@@ -53,7 +65,15 @@
       "ROUTE_CREATION": "Create Route",
       "CONSUMER_CREATION": "New Consumer",
       "PLUGIN_CREATION": "Filter plugins"
-    }
+    },
+    "TEMP": [
+      "serviceName",
+      "routeName",
+      "serviceId",
+      "routeId",
+      "serviceData",
+      "routeData"
+    ]
   },
   "specPattern": [
     "**/*.km.js",

--- a/env.config/km.local.json
+++ b/env.config/km.local.json
@@ -10,8 +10,11 @@
       "HOMEPAGE": "/workspaces",
       "OVERVIEW": "/overview",
       "SERVICES": "/services",
+      "SERVICES_CREATION": "/services/create",
       "CONSUMERS": "/consumers",
+      "CONSUMERS_CREATION": "/consumers/create",
       "PLUGINS": "/plugins",
+      "PLUGINS_CREATION": "/plugins/create",
       "ROUTES": "/routes",
       "ROUTES_CREATION": "/routes/create"
     },
@@ -20,6 +23,9 @@
     },
     "SELECTORS": {
       "ACTION_BUTTON": "action-button",
+      "EMPTY_STATE_ACTION": "empty-state-action",
+      "ADD_ROUTE": "toolbar-add-route",
+      "ADD_SERVICE": "toolbar-add-gateway-service",
       "SERVICE_FORM_SUBMIT": "service-create-form-submit",
       "SERVICE_FORM_INPUT_NAME": "gateway-service-name-input",
       "SERVICE_FORM_INPUT_HOST": "gateway-service-host-input",
@@ -27,6 +33,7 @@
       "SERVICE_FORM_INPUT_URL": "gateway-service-url-input",
       "SERVICE_PROTOCOL_LABEL": "gateway-service-protocol-radio-label",
       "SERVICE_URL_LABEL": "gateway-service-url-radio-label",
+      "SERVICE_SELECT_INPUT": "input[placeholder=\"Select a service\"]",
       "SELECT_WRAPPER": "select-wrapper",
       "SELECT_ITEM_PREFIX": "select-item-",
       "FORM_ERROR": "form-error",
@@ -40,6 +47,12 @@
         "Consumers",
         "Plugins"
       ]
+    },
+    "LABELS": {
+      "SERVICE_CREATION": "New Gateway Service",
+      "ROUTE_CREATION": "Create Route",
+      "CONSUMER_CREATION": "New Consumer",
+      "PLUGIN_CREATION": "Filter plugins"
     }
   },
   "specPattern": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kong-assignment",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Technical exercise for Kong",
   "homepage": "https://github.com/alecmestroni/kong-assignment#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kong-assignment",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Technical exercise for Kong",
   "homepage": "https://github.com/alecmestroni/kong-assignment#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kong-assignment",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Technical exercise for Kong",
   "homepage": "https://github.com/alecmestroni/kong-assignment#readme",
   "bugs": {


### PR DESCRIPTION
- Reorganize tests into feature directories
- Add creation evn for all Kong entities (path and labels)
- Add route navigation test
- Enhance service navigation test coverage
- Add createItem admin command
- Add route creation form tests for basic and full scenarios
- Add route management commands for form compilation and validation
- Extend admin commands with proper error handling and cleanup functionality
- Add route property fixtures for default and full configurations
- Add route creation workflow with service association
- Improve common commands
- Update Cypress config with retry mechanism for avoid cross-origin exceptions
- Bump version to 0.4.0